### PR TITLE
fix: spotify widget status text

### DIFF
--- a/src/components/SpotifyWidget.tsx
+++ b/src/components/SpotifyWidget.tsx
@@ -65,9 +65,9 @@ const SpotifyWidget: React.FC = () => {
   }
 
   return (
-    <div className="flex flex-col sm:flex-row items-center sm:items-start sm:space-x-3 space-y-2 sm:space-y-0 max-w-full sm:max-w-xs group">
-      {/* Album Art (clickable on mobile) */}
-    {track?.isPlaying ? (
+    <>
+    <div className="flex flex-col gap-2 items-center justify-center sm:items-start sm:justify-start">
+     {track?.isPlaying ? (
       <div className="text-soft-royal-blue">
         <h2 className="inter-bold">Currently Playing</h2>
       </div>
@@ -76,6 +76,8 @@ const SpotifyWidget: React.FC = () => {
         <h2 className="inter-bold">Last Played</h2>
       </div>
     )}
+    <div className="flex flex-col sm:flex-row items-center sm:items-start sm:space-x-3 space-y-2 sm:space-y-0 max-w-full sm:max-w-xs group">
+      {/* Album Art (clickable on mobile) */}
       <a
         href={track?.songUrl}
         target="_blank"
@@ -92,7 +94,7 @@ const SpotifyWidget: React.FC = () => {
       {/* Track Info */}
       <div className="flex-1 min-w-0 text-center sm:text-left">
         <h4 className="sg-semibold text-silver text-sm truncate">{track?.title}</h4>
-        <h4 className="sg-semibold text-silver text-sm truncate">{track?.album}</h4>
+        <p className="inter-regular text-battleship-gray text-xs truncate">{track?.album}</p>
         <p className="inter-regular text-battleship-gray text-xs truncate">
           {track?.artist}
         </p>
@@ -109,6 +111,8 @@ const SpotifyWidget: React.FC = () => {
         <ExternalLink className="w-5 h-5" />
       </a>
     </div>
+    </div>
+    </>
   );
 };
 

--- a/src/components/SpotifyWidget.tsx
+++ b/src/components/SpotifyWidget.tsx
@@ -64,20 +64,6 @@ const SpotifyWidget: React.FC = () => {
     );
   }
 
-  // Not playing state
-  if (!track?.isPlaying) {
-    return (
-      <div className="flex flex-col sm:flex-row items-center sm:items-start space-y-2 sm:space-y-0 sm:space-x-3 text-battleship-gray w-full max-w-xs">
-        <div className="w-12 h-12 bg-battleship-gray bg-opacity-20 rounded-lg flex items-center justify-center shrink-0">
-          <Music className="w-5 h-5" />
-        </div>
-        <p className="inter-medium text-sm text-center sm:text-left truncate w-full">
-          Currently not listening to anything
-        </p>
-      </div>
-    );
-  }
-
   return (
     <div className="flex flex-col sm:flex-row items-center sm:items-start sm:space-x-3 space-y-2 sm:space-y-0 max-w-full sm:max-w-xs group">
       {/* Album Art (clickable on mobile) */}

--- a/src/components/SpotifyWidget.tsx
+++ b/src/components/SpotifyWidget.tsx
@@ -68,13 +68,13 @@ const SpotifyWidget: React.FC = () => {
     <div className="flex flex-col sm:flex-row items-center sm:items-start sm:space-x-3 space-y-2 sm:space-y-0 max-w-full sm:max-w-xs group">
       {/* Album Art (clickable on mobile) */}
       <a
-        href={track.songUrl}
+        href={track?.songUrl}
         target="_blank"
         rel="noopener noreferrer"
         className="relative shrink-0"
       >
         <img
-          src={track.albumArt}
+          src={track?.albumArt}
           alt="Album cover"
           className="w-12 h-12 rounded-lg shadow-md hover:opacity-90 transition"
         />
@@ -82,15 +82,15 @@ const SpotifyWidget: React.FC = () => {
 
       {/* Track Info */}
       <div className="flex-1 min-w-0 text-center sm:text-left">
-        <h4 className="sg-semibold text-silver text-sm truncate">{track.title}</h4>
+        <h4 className="sg-semibold text-silver text-sm truncate">{track?.title}</h4>
         <p className="inter-regular text-battleship-gray text-xs truncate">
-          {track.artist}
+          {track?.artist}
         </p>
       </div>
 
       {/* Spotify Link (hidden on very small screens, shown on sm+) */}
       <a
-        href={track.songUrl}
+        href={track?.songUrl}
         target="_blank"
         rel="noopener noreferrer"
         className="hidden sm:flex text-soft-royal-blue hover:text-blue-crayola transition-all duration-200 opacity-70 hover:opacity-100 hover:scale-110 cursor-pointer"

--- a/src/components/SpotifyWidget.tsx
+++ b/src/components/SpotifyWidget.tsx
@@ -67,6 +67,15 @@ const SpotifyWidget: React.FC = () => {
   return (
     <div className="flex flex-col sm:flex-row items-center sm:items-start sm:space-x-3 space-y-2 sm:space-y-0 max-w-full sm:max-w-xs group">
       {/* Album Art (clickable on mobile) */}
+    {track?.isPlaying ? (
+      <div className="text-soft-royal-blue">
+        <h2 className="inter-bold">Currently Playing</h2>
+      </div>
+    ) : (
+      <div className="text-battleship-gray">
+        <h2 className="inter-bold">Last Played</h2>
+      </div>
+    )}
       <a
         href={track?.songUrl}
         target="_blank"
@@ -83,6 +92,7 @@ const SpotifyWidget: React.FC = () => {
       {/* Track Info */}
       <div className="flex-1 min-w-0 text-center sm:text-left">
         <h4 className="sg-semibold text-silver text-sm truncate">{track?.title}</h4>
+        <h4 className="sg-semibold text-silver text-sm truncate">{track?.album}</h4>
         <p className="inter-regular text-battleship-gray text-xs truncate">
           {track?.artist}
         </p>


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Update SpotifyWidget to show a status header, display album, and safely handle missing track data via optional chaining.
> 
> - **Frontend**
>   - **`src/components/SpotifyWidget.tsx`**:
>     - Replace not-playing fallback with status header showing `Currently Playing` or `Last Played`.
>     - Add album display and use optional chaining on `track` fields/links (`songUrl`, `albumArt`, `title`, `album`, `artist`).
>     - Wrap content in a container for layout adjustments.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c46ef857baf8c70f3583507df774db1a4fe1d94b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->