### PR TITLE
Fix UI bug by removing redundant song status check

### DIFF
--- a/server/index.ts
+++ b/server/index.ts
@@ -108,9 +108,7 @@ app.get("/now-playing", async (req: Request, res: Response) => {
             }
         );
 
-        if (nowPlaying.status === 204 || !nowPlaying.data) {
-            return res.json({ isPlaying: false, message: "No song currently playing" });
-        }
+        //no need to check if is_playing is false this will cause a ui bug in front end as client side expects past song details ig isPLaying is false
 
         const song = nowPlaying.data.item;
         const isPlaying = nowPlaying.data.is_playing;


### PR DESCRIPTION
The client expects song details in the response. However, when isPlaying is false, the backend was returning a generic response instead of the last known song data. This mismatch between the client’s expectations and the server’s response caused the UI to break.


<img width="1582" height="946" alt="Screenshot 2025-12-24 at 3 12 10 AM" src="https://github.com/user-attachments/assets/508be99e-bf05-49e8-828c-2d753b4636b6" />

