### PR TITLE
feat: add handwritten hint annotations on home page

### DIFF
--- a/src/components/CurrentlyWorking.tsx
+++ b/src/components/CurrentlyWorking.tsx
@@ -1,19 +1,39 @@
+import { useState } from 'react'
 import data from '../../constants/projects.json'
 import { LinkPreview } from './LinkPreview';
+import { HandwrittenHint } from './HandwrittenHint';
 
 const {projects} = data;
 
 function CurrentlyWorking() {
+    const [showHint, setShowHint] = useState(true)
 
     return (
         <div className="text-battleship-gray flex flex-col gap-1 sm:gap-0 text-xl ">
             <div className="inter-bold">Currently Working</div>
             {projects.map((value, index) => {
-                return (<>
-                    <div key={index} className="flex whitespace-nowrap gap-2 items-center">
+                return (
+                    <div
+                        key={index}
+                        className="relative flex whitespace-nowrap gap-2 items-center overflow-visible"
+                    >
+                        {index === 0 && (
+                            <HandwrittenHint
+                                visible={showHint}
+                                text="hover me for a sneak peek!"
+                                arrowPath="M 5 12 L 18 11 L 32 13 L 43 12 M 36 7 L 43 12 L 36 17"
+                                arrowViewBox="0 0 50 25"
+                                arrowWidth={75}
+                                arrowHeight={38}
+                                flexDir="flex-row-reverse"
+                                textRotation="rotate-1"
+                                className="right-full mr-3 top-1/2 -translate-y-1/2 hidden md:flex"
+                            />
+                        )}
+                        <span onMouseEnter={index === 0 ? () => setShowHint(false) : undefined}>
                         {value['image'] ? (
-                            <LinkPreview 
-                                url={value['url']} 
+                            <LinkPreview
+                                url={value['url']}
                                 isStatic={true}
                                 imageSrc={value['image']}
                                 className="hover:underline inter-medium text-xl"
@@ -21,13 +41,14 @@ function CurrentlyWorking() {
                                 {value['text']}
                             </LinkPreview>
                         ) : (
-                            <LinkPreview 
-                                url={value['url']} 
+                            <LinkPreview
+                                url={value['url']}
                                 className="hover:underline inter-medium text-xl"
                             >
                                 {value['text']}
                             </LinkPreview>
                         )}
+                        </span>
                         {value['live'] && (
                             <a 
                                 href={value['live']} 
@@ -40,7 +61,6 @@ function CurrentlyWorking() {
                         )}
                         <p className="inter-medium text-xl truncate">- {value['desc']}</p>
                     </div>
-                </>
                 )
             })}
 

--- a/src/components/HandwrittenHint.tsx
+++ b/src/components/HandwrittenHint.tsx
@@ -1,0 +1,70 @@
+import { motion, AnimatePresence } from 'framer-motion'
+
+interface HandwrittenHintProps {
+  visible: boolean
+  text: string
+  /** SVG path d string — main curve + arrowhead as one composite path */
+  arrowPath: string
+  arrowViewBox?: string
+  arrowWidth?: number
+  arrowHeight?: number
+  /** Tailwind flex-direction class, e.g. 'flex-col', 'flex-row', 'flex-col-reverse' */
+  flexDir?: string
+  /** Tailwind items-* alignment class */
+  alignment?: string
+  /** Tailwind rotate class for the text */
+  textRotation?: string
+  /** Extra classes on the outer absolute div */
+  className?: string
+}
+
+export function HandwrittenHint({
+  visible,
+  text,
+  arrowPath,
+  arrowViewBox = '0 0 30 35',
+  arrowWidth = 30,
+  arrowHeight = 35,
+  flexDir = 'flex-col',
+  alignment = 'items-center',
+  textRotation = '-rotate-2',
+  className = '',
+}: HandwrittenHintProps) {
+  return (
+    <AnimatePresence>
+      {visible && (
+        <motion.div
+          className={`pointer-events-none select-none absolute flex ${alignment} ${flexDir} ${className}`}
+          initial={{ opacity: 0 }}
+          animate={{ opacity: 1 }}
+          exit={{ opacity: 0 }}
+          transition={{ duration: 0.5, delay: 0.6 }}
+        >
+          <svg
+            width={arrowWidth}
+            height={arrowHeight}
+            viewBox={arrowViewBox}
+            className="text-battleship-gray/65 shrink-0"
+          >
+            <motion.path
+              d={arrowPath}
+              stroke="currentColor"
+              strokeWidth="2"
+              fill="none"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              initial={{ pathLength: 0 }}
+              animate={{ pathLength: 1 }}
+              transition={{ delay: 1.0, duration: 0.9, ease: 'easeOut' }}
+            />
+          </svg>
+          <span
+            className={`caveat text-battleship-gray/65 text-2xl whitespace-nowrap inline-block ${textRotation}`}
+          >
+            {text}
+          </span>
+        </motion.div>
+      )}
+    </AnimatePresence>
+  )
+}

--- a/src/components/NavBar.tsx
+++ b/src/components/NavBar.tsx
@@ -4,6 +4,7 @@ import { Menu, X } from "lucide-react"; // hamburger icons
 import DiscordWidget from "./OnlineStatus";
 import WeatherWidget from "./WeatherWidget";
 import { ThemeToggle } from "./ThemeToggle";
+import { HandwrittenHint } from "./HandwrittenHint";
 
 
 export const NavBar = () => {
@@ -11,6 +12,7 @@ export const NavBar = () => {
     const currentPath = location.pathname;
     const [isOpen, setIsOpen] = useState(false);
     const [scrolled, setScrolled] = useState(false);
+    const [showThemeHint, setShowThemeHint] = useState(true);
 
     useEffect(() => {
         const handleScroll = () => {
@@ -67,7 +69,25 @@ export const NavBar = () => {
                             {link}
                         </a>
                     ))}
-                <ThemeToggle />
+                {/* Theme toggle with handwritten hint on home page */}
+                <div
+                    className="relative overflow-visible"
+                    onClick={() => setShowThemeHint(false)}
+                >
+                    <HandwrittenHint
+                        visible={showThemeHint && currentPath === '/'}
+                        text="try changing the theme!"
+                        arrowPath="M 21 31 L 22 23 L 20 14 L 21 4 M 15 10 L 21 4 L 27 10"
+                        arrowViewBox="0 0 30 33"
+                        arrowWidth={45}
+                        arrowHeight={50}
+                        flexDir="flex-col"
+                        alignment="items-end"
+                        textRotation="-rotate-3"
+                        className="top-full right-0 mt-1"
+                    />
+                    <ThemeToggle />
+                </div>
             </div>
 
 

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -1,4 +1,4 @@
-@import url('https://fonts.googleapis.com/css2?family=Inter:ital,opsz,wght@0,14..32,100..900;1,14..32,100..900&family=Space+Grotesk:wght@300..700&display=swap');
+@import url('https://fonts.googleapis.com/css2?family=Caveat:wght@400..700&family=Inter:ital,opsz,wght@0,14..32,100..900;1,14..32,100..900&family=Space+Grotesk:wght@300..700&display=swap');
 @import 'tailwindcss';
 
 
@@ -84,6 +84,12 @@
   font-family: 'Inter', sans-serif;
   font-optical-sizing: auto;
   font-weight: 900;
+  font-style: normal;
+}
+.caveat {
+  font-family: 'Caveat', cursive;
+  font-optical-sizing: auto;
+  font-weight: 500;
   font-style: normal;
 }
 


### PR DESCRIPTION
- Add HandwrittenHint component with SVG draw-in animation (framer-motion)
- Add Caveat handwriting font
- Theme toggle hint on desktop home page, dismisses on first toggle click
- Project hover hint pointing at first project name, dismisses on hover